### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,15 +18,15 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "chiiya/tmdb-php": "^1.0",
-        "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0",
+        "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.92"
     },
     "require-dev": {
         "chiiya/laravel-code-style": "^3.2",
         "nunomaduro/collision": "^8.8",
-        "orchestra/testbench": "^10.6",
+        "orchestra/testbench": "^10.6|^11.0",
         "phpunit/phpunit": "^12.3",
         "squizlabs/php_codesniffer": "^3.0"
     },


### PR DESCRIPTION
- Update PHP requirement from ^8.2 to ^8.3 (Laravel 13 requires PHP 8.3+)
- Add ^13.0 to illuminate/contracts version constraint
- Add ^11.0 to orchestra/testbench for Laravel 13 testing support